### PR TITLE
Add terms and conditions feature

### DIFF
--- a/ftw/noticeboard/browser/conditions.py
+++ b/ftw/noticeboard/browser/conditions.py
@@ -1,0 +1,17 @@
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from zope.publisher.browser import BrowserView
+from ftw.noticeboard.content.category import INoticeCategory
+from ftw.noticeboard.content.notice import INotice
+
+
+class TermsAndConditions(BrowserView):
+
+    template = ViewPageTemplateFile('templates/conditions.pt')
+
+    def __call__(self):
+        self.category = None
+        if INoticeCategory.providedBy(self.context):
+            self.category = self.context
+        elif INotice.providedBy(self.context):
+            self.category = self.context.aq_parent
+        return self.template()

--- a/ftw/noticeboard/browser/configure.zcml
+++ b/ftw/noticeboard/browser/configure.zcml
@@ -1,0 +1,24 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser"
+    xmlns:plone="http://namespaces.plone.org/plone"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
+    i18n_domain="ftw.noticeboard">
+
+
+    <browser:page
+        for="ftw.noticeboard.content.notice.INotice"
+        name="terms-and-conditions"
+        permission="zope2.View"
+        class=".conditions.TermsAndConditions"
+        />
+
+    <browser:page
+        for="ftw.noticeboard.content.category.INoticeCategory"
+        name="terms-and-conditions"
+        permission="zope2.View"
+        class=".conditions.TermsAndConditions"
+        />
+
+
+</configure>

--- a/ftw/noticeboard/browser/templates/conditions.pt
+++ b/ftw/noticeboard/browser/templates/conditions.pt
@@ -1,0 +1,16 @@
+<html xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      metal:use-macro="context/main_template/macros/master"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      i18n:domain="ftw.noticeboard">
+
+    <metal:content-title fill-slot="content-title">
+        <h1 class="documentFirstHeading" i18n:translate="">
+            Terms and conditions for "<span i18n:name="title" tal:content="view/category/title" />"
+        </h1>
+    </metal:content-title>
+
+    <div metal:fill-slot="content-core">
+        <div class="terms-and-conditions" tal:content="structure view/category/conditions/output"/>
+    </div>
+</html>

--- a/ftw/noticeboard/configure.zcml
+++ b/ftw/noticeboard/configure.zcml
@@ -7,6 +7,7 @@
 
     <five:registerPackage package="." initialize=".initialize" />
     <include file="permissions.zcml" />
+    <include package=".browser" />
     <include package=".content" />
 
     <genericsetup:registerProfile

--- a/ftw/noticeboard/configure.zcml
+++ b/ftw/noticeboard/configure.zcml
@@ -7,6 +7,7 @@
 
     <five:registerPackage package="." initialize=".initialize" />
     <include file="permissions.zcml" />
+    <include package=".content" />
 
     <genericsetup:registerProfile
         name="default"

--- a/ftw/noticeboard/content/category.py
+++ b/ftw/noticeboard/content/category.py
@@ -1,5 +1,9 @@
+from ftw.noticeboard import _
+from plone.app.textfield import RichText
+from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.content import Container
 from plone.supermodel import model
+from zope.interface import alsoProvides
 from zope.interface import implements
 from zope.interface import Interface
 
@@ -11,6 +15,16 @@ class INoticeCategory(Interface):
 class INoticeCategorySchema(model.Schema):
     """A Folderish type for notices categories, which holds notices"""
 
+    conditions = RichText(
+        title=_(u'label_conditions', default=u'Terms and Conditions'),
+        description=_(u'description_conditions',
+                      default=u'Those conditions needs to be accepted for posting in this category'),
+        required=True,
+        allowed_mime_types=('text/html',))
+
 
 class NoticeCategory(Container):
     implements(INoticeCategory)
+
+
+alsoProvides(INoticeCategory, IFormFieldProvider)

--- a/ftw/noticeboard/content/configure.zcml
+++ b/ftw/noticeboard/content/configure.zcml
@@ -1,0 +1,7 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    i18n_domain="ftw.noticeboard">
+
+    <adapter factory=".notice.AcceptedTermsAndConditions" />
+
+</configure>

--- a/ftw/noticeboard/content/notice.py
+++ b/ftw/noticeboard/content/notice.py
@@ -21,7 +21,7 @@ class INoticeSchema(model.Schema):
         title=_(u'label_accept_conditions', default=u'Terms and Conditions'),
         description=_(u'description_accept_conditions',
                       default=u'Please accept the '
-                      '<a target="_blank" href="./terms_and_conditions">terms and conditions</a>'),
+                      '<a target="_blank" href="./terms-and-conditions">terms and conditions</a>'),
         default=False)
 
 

--- a/ftw/noticeboard/content/notice.py
+++ b/ftw/noticeboard/content/notice.py
@@ -1,9 +1,13 @@
+from ftw.noticeboard import _
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.content import Container
 from plone.supermodel import model
+from z3c.form import validator
+from zope import schema
 from zope.interface import alsoProvides
 from zope.interface import implements
 from zope.interface import Interface
+from zope.interface import Invalid
 
 
 class INotice(Interface):
@@ -13,9 +17,31 @@ class INotice(Interface):
 class INoticeSchema(model.Schema):
     """A Folderish type for notices, which may hold images"""
 
+    accept_conditions = schema.Bool(
+        title=_(u'label_accept_conditions', default=u'Terms and Conditions'),
+        description=_(u'description_accept_conditions',
+                      default=u'Please accept the '
+                      '<a target="_blank" href="./terms_and_conditions">terms and conditions</a>'),
+        default=False)
+
 
 class Notice(Container):
     implements(INotice)
 
 
 alsoProvides(INoticeSchema, IFormFieldProvider)
+
+
+class AcceptedTermsAndConditions(validator.SimpleFieldValidator):
+    """ z3c.form validator class for international phone numbers """
+
+    def validate(self, value):
+        if not value:
+            raise Invalid(_(u'You need to accept the terms and conditions'))
+        return
+
+
+validator.WidgetValidatorDiscriminators(
+    AcceptedTermsAndConditions,
+    field=INoticeSchema['accept_conditions']
+)

--- a/ftw/noticeboard/profiles/default/types/ftw.noticeboard.NoticeBoard.xml
+++ b/ftw/noticeboard/profiles/default/types/ftw.noticeboard.NoticeBoard.xml
@@ -16,7 +16,7 @@
     </property>
 
     <!-- schema interface -->
-    <property name="schema">ftw.noticeboard.content.notice.INoticeBoardSchema</property>
+    <property name="schema">ftw.noticeboard.content.noticeboard.INoticeBoardSchema</property>
 
     <!-- class used for content items -->
     <property name="klass">ftw.noticeboard.content.noticeboard.NoticeBoard</property>

--- a/ftw/noticeboard/profiles/default/types/ftw.noticeboard.NoticeCategory.xml
+++ b/ftw/noticeboard/profiles/default/types/ftw.noticeboard.NoticeCategory.xml
@@ -16,7 +16,7 @@
     </property>
 
     <!-- schema interface -->
-    <property name="schema">ftw.noticeboard.content.notice.INoticeCategorySchema</property>
+    <property name="schema">ftw.noticeboard.content.category.INoticeCategorySchema</property>
 
     <!-- class used for content items -->
     <property name="klass">ftw.noticeboard.content.category.NoticeCategory</property>

--- a/ftw/noticeboard/tests/test_add_content.py
+++ b/ftw/noticeboard/tests/test_add_content.py
@@ -3,14 +3,19 @@ from ftw.builder import create
 from ftw.noticeboard.tests import FunctionalTestCase
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
+from ftw.testbrowser.pages import statusmessages
 from ftw.testbrowser.pages import plone
+from plone.app.textfield.value import RichTextValue
 
 
 class TestContentTypes(FunctionalTestCase):
 
+    def setUp(self):
+        super(TestContentTypes, self).setUp()
+        self.grant('Manager')
+
     @browsing
     def test_add_noticeboard(self, browser):
-        self.grant('Manager')
         browser.login().visit()
         factoriesmenu.add('NoticeBoard')
         browser.fill({'Title': u'This is our NoticeBoard'})
@@ -19,25 +24,39 @@ class TestContentTypes(FunctionalTestCase):
 
     @browsing
     def test_add_noticecategory(self, browser):
-        self.grant('Manager')
-
         noticeboard = create(Builder('noticeboard').titled(u'Noticeboard'))
 
         browser.login().visit(noticeboard)
         factoriesmenu.add('NoticeCategory')
-        browser.fill({'Title': u'This is a Category'})
+        browser.fill({'Title': u'This is a Category', 'Terms and Conditions': 'Anything'})
         browser.find_button_by_label('Save').click()
         self.assertEquals(u'This is a Category', plone.first_heading())
 
     @browsing
     def test_add_notice(self, browser):
-        self.grant('Manager')
-
         noticeboard = create(Builder('noticeboard').titled(u'Noticeboard'))
-        category = create(Builder('noticecategory').titled(u'Category').within(noticeboard))
+        category = create(Builder('noticecategory')
+                          .having(conditions=RichTextValue('Something'))
+                          .titled(u'Category')
+                          .within(noticeboard))
+
+        browser.login().visit(category)
+        factoriesmenu.add('Notice')
+        browser.fill({'Title': u'This is a Notice', 'Terms and Conditions': True})
+        browser.find_button_by_label('Save').click()
+        self.assertEquals(u'This is a Notice', plone.first_heading())
+
+    @browsing
+    def test_terms_and_conditions_need_to_be_accepted(self, browser):
+        noticeboard = create(Builder('noticeboard').titled(u'Noticeboard'))
+        category = create(Builder('noticecategory')
+                          .having(conditions=RichTextValue('Something'))
+                          .titled(u'Category')
+                          .within(noticeboard))
 
         browser.login().visit(category)
         factoriesmenu.add('Notice')
         browser.fill({'Title': u'This is a Notice'})
         browser.find_button_by_label('Save').click()
-        self.assertEquals(u'This is a Notice', plone.first_heading())
+        self.assertEquals(u'Add Notice', plone.first_heading())
+        statusmessages.assert_message('There were some errors.')


### PR DESCRIPTION
This PR makes it required for a user to accept the terms and conditions before posting a new Notice 

- Terms and conditions are defined per category
- z3c form validator is need, since "boolean" fields cannot be `required` for obvious reasons.
- View