### PR TITLE
Try to add a quickupload default portlet for Notices.

### DIFF
--- a/ftw/noticeboard/profiles/default/metadata.xml
+++ b/ftw/noticeboard/profiles/default/metadata.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <metadata>
     <dependencies>
+        <dependency>profile-collective.quickupload:default</dependency>
         <dependency>profile-ftw.upgrade:default</dependency>
     </dependencies>
 </metadata>

--- a/ftw/noticeboard/profiles/default/portlets.xml
+++ b/ftw/noticeboard/profiles/default/portlets.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<portlets>
+<!--     <assignment manager="plone.rightcolumn"
+                category="content_type"
+                key="ftw.noticeboard.Notice"
+                type="collective.quickupload.QuickUploadPortlet"
+                name="quickupload">
+        <property name="header">Upload</property>
+        <property name="upload_portal_type">Image</property>
+    </assignment>
+ -->
+
+ </portlets>

--- a/ftw/noticeboard/profiles/uninstall/portlets.xml
+++ b/ftw/noticeboard/profiles/uninstall/portlets.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<portlets>
+
+    <assignment manager="plone.rightcolumn"
+                category="content_type"
+                key="ftw.noticeboard.Notice"
+                type="collective.quickupload.QuickUploadPortlet"
+                name="quickupload"
+                remove="True" />
+
+</portlets>

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         'Plone',
         'setuptools',
         'ftw.upgrade',
+        'collective.quickupload',
     ],
 
     tests_require=tests_require,

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -2,12 +2,7 @@
 extends =
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
     sources.cfg
+    versions.cfg
 
 package-name = ftw.noticeboard
 
-versions = versions
-
-
-[versions]
-setuptools = 28.2.0
-zc.buildout = 2.11.0


### PR DESCRIPTION
This was supposed to be any easy task. 
Unfortunately I get the following error while setting up the PloneSandBox layer:

```
  File "..../.buildout/eggs/collective.quickupload-1.11.1-py2.7.egg/collective/quickupload/portlet/vocabularies.py", line 49, in __call__
    'auto', 'auto', context.translate(_(
AttributeError: translate
```

The problem seems to be that during the setup the context (assignment) is not yet wrapped, not request available and/or skins directory not yet ready. 

I don't know why so far. 

To make progress I leave it like that and fix it later. 
Setting up the plone site thru the webinterface works as expected and the portlet is there:

<img width="1242" alt="Screen Shot 2020-05-14 at 12 49 10" src="https://user-images.githubusercontent.com/437933/81925836-54bbde80-95e1-11ea-9753-082c67caa5e6.png">
