### PR TITLE
Add a modified (default dates) IPublication behavior using ftw.datepicker as widget

### DIFF
--- a/ftw/noticeboard/content/behaviors.py
+++ b/ftw/noticeboard/content/behaviors.py
@@ -1,0 +1,57 @@
+from ftw.datepicker.widget import DateTimePickerWidgetFactory
+from plone.app.dexterity import PloneMessageFactory as _PMF
+from plone.app.dexterity.behaviors.metadata import DCFieldProperty
+from plone.app.dexterity.behaviors.metadata import MetadataBase
+from plone.autoform import directives
+from plone.autoform.interfaces import IFormFieldProvider
+from plone.supermodel import model
+from zope import schema
+from zope.interface import alsoProvides
+import datetime
+
+
+def start_date():
+    return datetime.datetime.today()
+
+
+def end_date():
+    return datetime.datetime.today() + datetime.timedelta(30)
+
+
+class INoticePublication(model.Schema):
+
+    directives.widget(effective=DateTimePickerWidgetFactory)
+    effective = schema.Datetime(
+        title=_PMF(u'label_effective_date', u'Publishing Date'),
+        description=_PMF(
+            u'help_effective_date',
+            default=u"If this date is in the future, the content will "
+                    u"not show up in listings and searches until this date."),
+        required=True,
+        defaultFactory=start_date
+    )
+
+    directives.widget(expires=DateTimePickerWidgetFactory)
+    expires = schema.Datetime(
+        title=_PMF(u'label_expiration_date', u'Expiration Date'),
+        description=_PMF(
+            u'help_expiration_date',
+            default=u"When this date is reached, the content will no"
+                    u"longer be visible in listings and searches."),
+        required=True,
+        defaultFactory=end_date
+    )
+
+
+class NoticePublication(MetadataBase):
+    effective = DCFieldProperty(
+        INoticePublication['effective'],
+        get_name='effective_date'
+    )
+    expires = DCFieldProperty(
+        INoticePublication['expires'],
+        get_name='expiration_date'
+    )
+
+
+alsoProvides(INoticePublication, IFormFieldProvider)

--- a/ftw/noticeboard/content/configure.zcml
+++ b/ftw/noticeboard/content/configure.zcml
@@ -1,7 +1,16 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
+    xmlns:plone="http://namespaces.plone.org/plone"
     i18n_domain="ftw.noticeboard">
 
     <adapter factory=".notice.AcceptedTermsAndConditions" />
+
+    <plone:behavior
+        title="Date range for Notices"
+        description="Adds effective date and expiration date fields to Notices"
+        provides=".behaviors.INoticePublication"
+        factory=".behaviors.NoticePublication"
+        for="plone.dexterity.interfaces.IDexterityContent"
+        />
 
 </configure>

--- a/ftw/noticeboard/profiles/default/metadata.xml
+++ b/ftw/noticeboard/profiles/default/metadata.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <metadata>
     <dependencies>
+        <dependency>profile-ftw.datepicker:default</dependency>
         <dependency>profile-collective.quickupload:default</dependency>
         <dependency>profile-ftw.upgrade:default</dependency>
     </dependencies>

--- a/ftw/noticeboard/profiles/default/types/ftw.noticeboard.Notice.xml
+++ b/ftw/noticeboard/profiles/default/types/ftw.noticeboard.Notice.xml
@@ -28,6 +28,7 @@
     <property name="behaviors">
         <element value="plone.app.content.interfaces.INameFromTitle" />
         <element value="plone.app.dexterity.behaviors.metadata.IBasic" />
+        <element value="ftw.noticeboard.content.behaviors.INoticePublication" />
     </property>
 
     <!-- View information -->

--- a/ftw/noticeboard/tests/test_publication_behavior.py
+++ b/ftw/noticeboard/tests/test_publication_behavior.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+from DateTime import DateTime
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.noticeboard.tests import FunctionalTestCase
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import factoriesmenu
+from ftw.testing import freeze
+from plone.app.textfield.value import RichTextValue
+
+
+class TestBehaviors(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestBehaviors, self).setUp()
+        self.grant('Manager')
+
+        noticeboard = create(Builder('noticeboard').titled(u'Noticeboard'))
+        self.category = create(Builder('noticecategory')
+                               .having(conditions=RichTextValue('Something'))
+                               .titled(u'Category')
+                               .within(noticeboard))
+
+    @browsing
+    def test_default_values_of_effective_and_expiration_date(self, browser):
+        browser.login().visit(self.category)
+
+        with freeze(datetime(2014, 5, 7, 12, 30)):
+            factoriesmenu.add('Notice')
+            browser.fill({'Title': u'This is a Notice', 'Terms and Conditions': True})
+            browser.find_button_by_label('Save').click()
+
+            context = browser.context
+            self.assertEquals(DateTime(), context.effective())
+            self.assertEquals(DateTime('2014/06/06 12:30:00'), context.expires())

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         'setuptools',
         'ftw.upgrade',
         'collective.quickupload',
+        'ftw.datepicker',
     ],
 
     tests_require=tests_require,


### PR DESCRIPTION
The default IPublication behavior was not quite suitable. So for easier customizations I added a custom one to Notices

<img width="606" alt="Screen Shot 2020-05-14 at 16 10 36" src="https://user-images.githubusercontent.com/437933/81944793-86db3980-95fd-11ea-91f0-30f8927fef3a.png">

Changes.
- default schemata
- default values
- Better date/time picker widget

Note: The order of the fields is not yet implemented. Will follow later. 
