### PR TITLE
Add noticeboard default view.

### DIFF
--- a/ftw/noticeboard/browser/configure.zcml
+++ b/ftw/noticeboard/browser/configure.zcml
@@ -20,5 +20,13 @@
         class=".conditions.TermsAndConditions"
         />
 
+    <browser:page
+        for="ftw.noticeboard.content.noticeboard.INoticeBoard"
+        name="noticeboard_view"
+        permission="zope2.View"
+        class=".noticeboard.NoticeBoardView"
+        template="templates/noticeboard.pt"
+        />
+
 
 </configure>

--- a/ftw/noticeboard/browser/noticeboard.py
+++ b/ftw/noticeboard/browser/noticeboard.py
@@ -1,0 +1,34 @@
+from plone import api
+from zope.publisher.browser import BrowserView
+
+
+class NoticeBoardView(BrowserView):
+
+    def get_categories_and_notices(self):
+        """
+        Return a prepopulated structure for easy rendering in the template.
+        This method could be implented with just one catalog query.
+        But as off now there are propbably just a few 100 Notices per installation.
+        So caching and improved querying is not necessary right now.
+        """
+        catalog = api.portal.get_tool('portal_catalog')
+        results = []
+        categories = self.context.listFolderContents()  # not a catalog query
+
+        for category in categories:
+            notices = catalog(path='/'.join(category.getPhysicalPath()),
+                              portal_type='ftw.noticeboard.Notice')
+            results.append(
+                {
+                    'title': category.Title,
+                    'url': category.absolute_url(),
+                    'notices': [
+                        {
+                            'title': notice.Title,
+                            'url': notice.getURL(),
+                            'expires': api.portal.get_localized_time(notice.expires)
+                        } for notice in notices
+                    ]
+                }
+            )
+        return results

--- a/ftw/noticeboard/browser/templates/noticeboard.pt
+++ b/ftw/noticeboard/browser/templates/noticeboard.pt
@@ -1,0 +1,22 @@
+<html xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      metal:use-macro="context/main_template/macros/master"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      i18n:domain="ftw.noticeboard">
+
+    <div metal:fill-slot="content-core">
+        <tal:categories repeat="category view/get_categories_and_notices">
+            <div class="collapsible-head">
+                <h2 tal:content="category/title" />
+            </div>
+            <div class="collabsible-content">
+                <tal:notices repeat="notice category/notices">
+                    <div class="notice-wrapper">
+                        <span class="expiration-date" tal:content="notice/expires"/>
+                        <h3><a tal:attributes="href notice/url" tal:content="notice/title"/></h3>
+                    </div>
+                </tal:notices>
+            </div>
+        </tal:categories>
+    </div>
+</html>

--- a/ftw/noticeboard/content/notice.py
+++ b/ftw/noticeboard/content/notice.py
@@ -1,6 +1,7 @@
 from ftw.noticeboard import _
 from plone import api
 from plone.app.textfield import RichText
+from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.content import Container
 from plone.dexterity.utils import safe_unicode
@@ -43,6 +44,7 @@ class INoticeSchema(model.Schema):
         allowed_mime_types=('text/html',)
     )
 
+    directives.order_after(accept_conditions='*')
     accept_conditions = schema.Bool(
         title=_(u'label_accept_conditions', default=u'Terms and Conditions'),
         description=_(u'description_accept_conditions',

--- a/ftw/noticeboard/profiles/default/types/ftw.noticeboard.NoticeBoard.xml
+++ b/ftw/noticeboard/profiles/default/types/ftw.noticeboard.NoticeBoard.xml
@@ -31,7 +31,7 @@
     </property>
 
     <!-- View information -->
-    <property name="default_view">@@view</property>
+    <property name="default_view">@@noticeboard_view</property>
     <property name="default_view_fallback">False</property>
     <property name="view_methods">
     </property>

--- a/ftw/noticeboard/tests/test_add_content.py
+++ b/ftw/noticeboard/tests/test_add_content.py
@@ -15,6 +15,14 @@ class TestContentTypes(FunctionalTestCase):
         super(TestContentTypes, self).setUp()
         self.grant('Manager')
 
+    def _create_content(self):
+        noticeboard = create(Builder('noticeboard').titled(u'Noticeboard'))
+        category = create(Builder('noticecategory')
+                          .having(conditions=RichTextValue('Something'))
+                          .titled(u'Category')
+                          .within(noticeboard))
+        return noticeboard, category
+
     @browsing
     def test_add_noticeboard(self, browser):
         browser.login().visit()
@@ -35,12 +43,7 @@ class TestContentTypes(FunctionalTestCase):
 
     @browsing
     def test_add_notice(self, browser):
-        noticeboard = create(Builder('noticeboard').titled(u'Noticeboard'))
-        category = create(Builder('noticecategory')
-                          .having(conditions=RichTextValue('Something'))
-                          .titled(u'Category')
-                          .within(noticeboard))
-
+        board, category = self._create_content()
         browser.login().visit(category)
         factoriesmenu.add('Notice')
         browser.fill(
@@ -57,12 +60,7 @@ class TestContentTypes(FunctionalTestCase):
 
     @browsing
     def test_notice_default_value_email_field(self, browser):
-        noticeboard = create(Builder('noticeboard').titled(u'Noticeboard'))
-        category = create(Builder('noticecategory')
-                          .having(conditions=RichTextValue('Something'))
-                          .titled(u'Category')
-                          .within(noticeboard))
-
+        board, category = self._create_content()
         user = create(Builder('user').with_roles('Site Administrator'))
         login(self.portal, user.getId())
 
@@ -76,12 +74,7 @@ class TestContentTypes(FunctionalTestCase):
 
     @browsing
     def test_terms_and_conditions_need_to_be_accepted(self, browser):
-        noticeboard = create(Builder('noticeboard').titled(u'Noticeboard'))
-        category = create(Builder('noticecategory')
-                          .having(conditions=RichTextValue('Something'))
-                          .titled(u'Category')
-                          .within(noticeboard))
-
+        board, category = self._create_content()
         browser.login().visit(category)
         factoriesmenu.add('Notice')
         browser.fill(

--- a/ftw/noticeboard/tests/test_noticeboard_view.py
+++ b/ftw/noticeboard/tests/test_noticeboard_view.py
@@ -1,0 +1,75 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.noticeboard.tests import FunctionalTestCase
+from ftw.testbrowser import browsing
+from plone.app.textfield.value import RichTextValue
+
+
+class TestNoticeBoardView(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestNoticeBoardView, self).setUp()
+        self.grant('Manager')
+
+    def _create_content(self):
+        noticeboard = create(Builder('noticeboard').titled(u'Noticeboard'))
+        category1 = create(Builder('noticecategory')
+                           .having(conditions=RichTextValue('Something'))
+                           .titled(u'Category 1')
+                           .within(noticeboard))
+        category2 = create(Builder('noticecategory')
+                           .having(conditions=RichTextValue('Something'))
+                           .titled(u'Category 2')
+                           .within(noticeboard))
+
+        for number in range(1, 4):
+            create(Builder('notice')
+                   .titled(u'Notice {0}'.format(str(number)))
+                   .having(accept_conditions=True,
+                           text=RichTextValue('Something'),
+                           price='100')
+                   .within(category1))
+
+        for number in range(1, 2):
+            create(Builder('notice')
+                   .titled(u'Notice {0}'.format(str(number)))
+                   .having(accept_conditions=True,
+                           text=RichTextValue('Something'),
+                           price='100')
+                   .within(category2))
+
+        return noticeboard, category1, category2
+
+    @browsing
+    def test_view(self, browser):
+        noticeboard, cat1, cat2 = self._create_content()
+        browser.login().visit(noticeboard)
+
+        self.assertListEqual(
+            ['Category 1', 'Category 2'],
+            browser.css('.template-noticeboard_view .collapsible-head').text,
+            'Expected two categories'
+        )
+
+        self.assertEquals(
+            3,
+            len(browser.css('.collabsible-content').first.css('h3')),
+            'Expect 3 notices in first category'
+        )
+
+        self.assertEquals(
+            1,
+            len(browser.css('.collabsible-content')[1].css('h3')),
+            'Expect 1 notice in second category'
+        )
+
+    @browsing
+    def test_link_to_notice(self, browser):
+        noticeboard, cat1, cat2 = self._create_content()
+        notice = cat1.objectValues()[0]
+
+        browser.login().visit(noticeboard)
+        # Click on first link in first category
+        browser.css('.collabsible-content').first.css('h3 a').first.click()
+        self.assertEqual(notice.absolute_url(), browser.url)
+


### PR DESCRIPTION
- The default view shows all categories, with their notices.
- The HTML-Structure is ready for a collapsible integration using jQuery or pure CSS.


<img width="346" alt="Screen Shot 2020-05-15 at 10 53 51" src="https://user-images.githubusercontent.com/437933/82031632-73ca7700-969a-11ea-964a-8a1b8632a993.png">
