### PR TITLE
Re-use noticeboard view for category view, but show only items from the current category.

### DIFF
--- a/ftw/noticeboard/browser/category.py
+++ b/ftw/noticeboard/browser/category.py
@@ -1,0 +1,7 @@
+from ftw.noticeboard.browser.noticeboard import NoticeBoardView
+
+
+class NoticeCategoryView(NoticeBoardView):
+
+    def get_categories(self):
+        return [self.context]

--- a/ftw/noticeboard/browser/configure.zcml
+++ b/ftw/noticeboard/browser/configure.zcml
@@ -28,5 +28,12 @@
         template="templates/noticeboard.pt"
         />
 
+    <browser:page
+        for="ftw.noticeboard.content.category.INoticeCategory"
+        name="category_view"
+        permission="zope2.View"
+        class=".category.NoticeCategoryView"
+        template="templates/noticeboard.pt"
+        />
 
 </configure>

--- a/ftw/noticeboard/browser/noticeboard.py
+++ b/ftw/noticeboard/browser/noticeboard.py
@@ -4,6 +4,9 @@ from zope.publisher.browser import BrowserView
 
 class NoticeBoardView(BrowserView):
 
+    def get_categories(self):
+        return self.context.listFolderContents()  # not a catalog query
+
     def get_categories_and_notices(self):
         """
         Return a prepopulated structure for easy rendering in the template.
@@ -13,9 +16,8 @@ class NoticeBoardView(BrowserView):
         """
         catalog = api.portal.get_tool('portal_catalog')
         results = []
-        categories = self.context.listFolderContents()  # not a catalog query
 
-        for category in categories:
+        for category in self.get_categories():
             notices = catalog(path='/'.join(category.getPhysicalPath()),
                               portal_type='ftw.noticeboard.Notice')
             results.append(

--- a/ftw/noticeboard/profiles/default/types/ftw.noticeboard.NoticeCategory.xml
+++ b/ftw/noticeboard/profiles/default/types/ftw.noticeboard.NoticeCategory.xml
@@ -32,7 +32,7 @@
     </property>
 
     <!-- View information -->
-    <property name="default_view">@@view</property>
+    <property name="default_view">@@category_view</property>
     <property name="default_view_fallback">False</property>
     <property name="view_methods">
     </property>

--- a/ftw/noticeboard/tests/test_noticeboard_view.py
+++ b/ftw/noticeboard/tests/test_noticeboard_view.py
@@ -73,3 +73,26 @@ class TestNoticeBoardView(FunctionalTestCase):
         browser.css('.collabsible-content').first.css('h3 a').first.click()
         self.assertEqual(notice.absolute_url(), browser.url)
 
+    @browsing
+    def test_category_view(self, browser):
+        noticeboard, cat1, cat2 = self._create_content()
+        browser.login().visit(cat1)
+
+        self.assertEqual(
+            1,
+            len(browser.css('.collabsible-content')),
+            'Expect 1 content area')
+
+        self.assertEquals(
+            3,
+            len(browser.css('.collabsible-content').css('h3')),
+            'Expect 3 notices in first category'
+        )
+
+        browser.login().visit(cat2)
+
+        self.assertEquals(
+            1,
+            len(browser.css('.collabsible-content').css('h3')),
+            'Expect 1 notice in second category'
+        )


### PR DESCRIPTION
- With a small refactoring (`introduce get_categories`) I can re-use the same view for a single category.
- The obsolete title will be hidden thru CSS later.

<img width="401" alt="Screen Shot 2020-05-15 at 11 05 23" src="https://user-images.githubusercontent.com/437933/82033538-269bd480-969d-11ea-8633-5f9f6397f41e.png">

The category itself will not be accessible directly, but people can access them by entering the URL. So we simply show the categories content. 
