### PR TITLE
Add simple notice view with the html structure needed for styling.

### DIFF
--- a/ftw/noticeboard/browser/configure.zcml
+++ b/ftw/noticeboard/browser/configure.zcml
@@ -36,4 +36,13 @@
         template="templates/noticeboard.pt"
         />
 
+    <browser:page
+        for="ftw.noticeboard.content.notice.INotice"
+        name="notice_view"
+        permission="zope2.View"
+        class=".notice.NoticeView"
+        template="templates/notice.pt"
+        />
+
+
 </configure>

--- a/ftw/noticeboard/browser/notice.py
+++ b/ftw/noticeboard/browser/notice.py
@@ -1,0 +1,8 @@
+from plone import api
+from zope.publisher.browser import BrowserView
+
+
+class NoticeView(BrowserView):
+
+    def get_localized_expiration_date(self):
+        return api.portal.get_localized_time(self.context.expires())

--- a/ftw/noticeboard/browser/templates/notice.pt
+++ b/ftw/noticeboard/browser/templates/notice.pt
@@ -1,0 +1,32 @@
+<html xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      metal:use-macro="context/main_template/macros/master"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      i18n:domain="ftw.noticeboard">
+
+    <div metal:fill-slot="main">
+        <div class="notice-detail-wrapper">
+          <div class="notice-image-slider">
+            <tal:images repeat="image context/listFolderContents">
+              <div>
+                <img tal:replace="structure image/images/image/mini" />
+              </div>
+            </tal:images>
+          </div>
+          <div class="notice-details">
+              <span class="expiration-date" tal:content="view/get_localized_expiration_date"/>
+              <h1 class="documentFirstHeading" tal:content="context/title"/>
+              <div class="price">
+                <span class="label" i18n:translate="label_price">Price</span>
+                <span class="value" tal:content="context/price" />
+              </div>
+              <div class="contact">
+                <span class="label" i18n:translate="label_contact">Contact</span>
+                <span class="value" tal:content="context/email" />
+              </div>
+          </div>
+        </div>
+        <div class="notice-description" tal:condition="context/Description" tal:content="context/Description"/>
+        <div class="notice-text" tal:content="structure context/text/output"/>
+    </div>
+</html>

--- a/ftw/noticeboard/profiles/default/types/ftw.noticeboard.Notice.xml
+++ b/ftw/noticeboard/profiles/default/types/ftw.noticeboard.Notice.xml
@@ -32,7 +32,7 @@
     </property>
 
     <!-- View information -->
-    <property name="default_view">@@view</property>
+    <property name="default_view">@@notice_view</property>
     <property name="default_view_fallback">False</property>
     <property name="view_methods">
     </property>

--- a/ftw/noticeboard/tests/test_notice_view.py
+++ b/ftw/noticeboard/tests/test_notice_view.py
@@ -1,0 +1,44 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.noticeboard.tests import FunctionalTestCase
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import plone
+from plone.app.textfield.value import RichTextValue
+
+
+class TestNoticeView(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestNoticeView, self).setUp()
+        self.grant('Manager')
+
+    def _create_content(self):
+        noticeboard = create(Builder('noticeboard').titled(u'Noticeboard'))
+        category = create(Builder('noticecategory')
+                          .having(conditions=RichTextValue('Something'))
+                          .titled(u'Category')
+                          .within(noticeboard))
+        notice = create(Builder('notice')
+                        .titled(u'This is a N\xf6tice')
+                        .having(accept_conditions=True,
+                                text=RichTextValue(u'S\xf6mething'),
+                                price='100')
+                        .within(category))
+        return notice
+
+    @browsing
+    def test_list_images(self, browser):
+        notice = self._create_content()
+
+        for number in range(4):
+            create(Builder('image').within(notice).with_dummy_content())
+
+        browser.login().visit(notice)
+        self.assertEqual(
+            4,
+            len(browser.css('.notice-image-slider img')),
+            'Expect 4 images'
+        )
+
+        self.assertEquals(u'This is a N\xf6tice', plone.first_heading())
+        self.assertEquals(u'S\xf6mething', browser.css('.notice-text').first.text)


### PR DESCRIPTION
- Lists uploaded images using plone.app.imaging view (mini scale)
- All mandatory metadata (Title, Description, Text, Price)

<img width="843" alt="Screen Shot 2020-05-15 at 13 51 23" src="https://user-images.githubusercontent.com/437933/82047482-2f97a080-96b3-11ea-9f98-64248a3399a6.png">

