### PR TITLE
Implement minimal functionality on notice view.

### DIFF
--- a/ftw/noticeboard/browser/resources/styles.scss
+++ b/ftw/noticeboard/browser/resources/styles.scss
@@ -1,0 +1,33 @@
+.notice-detail-wrapper {
+
+  display: flex;
+  flex-wrap: nowrap;
+
+  .notice-image-slider {
+    width: 33%;
+    img {
+        width: 100%;
+        height: auto;
+    }
+  }
+
+  .notice-details {
+    display: block;
+    width: 67%;
+    padding-left: $padding-horizontal;
+  }
+
+  .label {
+    font-weight: normal;
+    display: block
+  }
+
+  .value {
+    font-weight: bold;
+  }
+}
+
+.notice-description {
+  margin: $margin-vertical 0;
+  font-weight: bold;
+}

--- a/ftw/noticeboard/browser/templates/notice.pt
+++ b/ftw/noticeboard/browser/templates/notice.pt
@@ -4,27 +4,42 @@
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       i18n:domain="ftw.noticeboard">
 
+    <head>
+        <div metal:fill-slot="javascript_head_slot" tal:omit-tag="">
+            <script type="text/javascript">
+              (function($){
+                const config = {
+                    adaptiveHeight: true,
+                }
+                $(document).ready(function(){
+                  $('.notice-image-slider').slick(config);
+                });
+              }(jQuery));
+            </script>
+        </div>
+    </head>
+
     <div metal:fill-slot="main">
         <div class="notice-detail-wrapper">
-          <div class="notice-image-slider">
-            <tal:images repeat="image context/listFolderContents">
-              <div>
-                <img tal:replace="structure image/images/image/mini" />
-              </div>
-            </tal:images>
-          </div>
-          <div class="notice-details">
-              <span class="expiration-date" tal:content="view/get_localized_expiration_date"/>
-              <h1 class="documentFirstHeading" tal:content="context/title"/>
-              <div class="price">
-                <span class="label" i18n:translate="label_price">Price</span>
-                <span class="value" tal:content="context/price" />
-              </div>
-              <div class="contact">
-                <span class="label" i18n:translate="label_contact">Contact</span>
-                <span class="value" tal:content="context/email" />
-              </div>
-          </div>
+            <div class="notice-image-slider">
+                <tal:images repeat="image context/listFolderContents">
+                    <div>
+                        <img tal:replace="structure image/images/image/large" />
+                    </div>
+                </tal:images>
+            </div>
+            <div class="notice-details">
+                <span class="expiration-date" tal:content="view/get_localized_expiration_date"/>
+                <h1 class="documentFirstHeading" tal:content="context/title"/>
+                <div class="price">
+                    <span class="label" i18n:translate="label_price">Price</span>
+                    <span class="value" tal:content="context/price" />
+                </div>
+                <div class="contact">
+                    <span class="label" i18n:translate="label_contact">Contact</span>
+                    <span class="value" tal:content="context/email" />
+                </div>
+            </div>
         </div>
         <div class="notice-description" tal:condition="context/Description" tal:content="context/Description"/>
         <div class="notice-text" tal:content="structure context/text/output"/>

--- a/ftw/noticeboard/configure.zcml
+++ b/ftw/noticeboard/configure.zcml
@@ -9,6 +9,7 @@
     <include file="permissions.zcml" />
     <include package=".browser" />
     <include package=".content" />
+    <include file="resources.zcml" />
 
     <genericsetup:registerProfile
         name="default"

--- a/ftw/noticeboard/profiles/default/metadata.xml
+++ b/ftw/noticeboard/profiles/default/metadata.xml
@@ -4,5 +4,6 @@
         <dependency>profile-ftw.datepicker:default</dependency>
         <dependency>profile-collective.quickupload:default</dependency>
         <dependency>profile-ftw.upgrade:default</dependency>
+        <dependency>profile-ftw.theming:default</dependency>
     </dependencies>
 </metadata>

--- a/ftw/noticeboard/profiles/default/metadata.xml
+++ b/ftw/noticeboard/profiles/default/metadata.xml
@@ -5,5 +5,6 @@
         <dependency>profile-collective.quickupload:default</dependency>
         <dependency>profile-ftw.upgrade:default</dependency>
         <dependency>profile-ftw.theming:default</dependency>
+        <dependency>profile-ftw.slider:default</dependency>
     </dependencies>
 </metadata>

--- a/ftw/noticeboard/resources.zcml
+++ b/ftw/noticeboard/resources.zcml
@@ -1,0 +1,12 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:theme="http://namespaces.zope.org/ftw.theming"
+    i18n_domain="ftw.noticeboard">
+
+    <include package="ftw.theming" file="meta.zcml" />
+
+    <theme:resources profile="ftw.noticeboard:default" slot="addon">
+        <theme:scss file="browser/resources/styles.scss" />
+    </theme:resources>
+
+</configure>

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
         'ftw.upgrade',
         'collective.quickupload',
         'ftw.datepicker',
+        'ftw.slider',
         'ftw.theming',
         'plone.api',
     ],

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
         'ftw.upgrade',
         'collective.quickupload',
         'ftw.datepicker',
+        'ftw.theming',
         'plone.api',
     ],
 


### PR DESCRIPTION
This PR also implements ftw.theming for styles and ftw.slider for the images on the notice view:

Still does not look great, since there is no actual theme installed. 

<img width="596" alt="Screen Shot 2020-05-15 at 15 56 18" src="https://user-images.githubusercontent.com/437933/82058314-dc2e4e00-96c4-11ea-946a-c1ecda48305c.png">
