### PR TITLE
Add w3c accessible toggler for categories on noticeboard.

### DIFF
--- a/ftw/noticeboard/browser/noticeboard.py
+++ b/ftw/noticeboard/browser/noticeboard.py
@@ -23,6 +23,7 @@ class NoticeBoardView(BrowserView):
             results.append(
                 {
                     'title': category.Title,
+                    'id': category.id,
                     'url': category.absolute_url(),
                     'notices': [
                         {

--- a/ftw/noticeboard/browser/resources/styles.scss
+++ b/ftw/noticeboard/browser/resources/styles.scss
@@ -22,6 +22,16 @@
   }
 }
 
+.template-category_view {
+    .collapsible-head {
+      display: none;
+    }
+
+    .collabsible-content[hidden] {
+      display: block;
+      margin-top: $margin-horizontal;
+    }
+}
 
 .notice-detail-wrapper {
 

--- a/ftw/noticeboard/browser/resources/styles.scss
+++ b/ftw/noticeboard/browser/resources/styles.scss
@@ -1,3 +1,28 @@
+.template-noticeboard_view {
+  ul {
+    @include ul(plain);    
+  }
+
+  .collapsible-head {
+    position: relative;
+    cursor: pointer;
+
+    .icon {
+      display: block;
+      position: absolute;
+      top: 25%;
+      right: 0;
+      margin-right: $margin-horizontal;
+      @extend .fa-icon;
+      @extend .fa-plus-circle;
+    }
+    &.open .icon {
+      @extend .fa-minus-circle; 
+    }
+  }
+}
+
+
 .notice-detail-wrapper {
 
   display: flex;

--- a/ftw/noticeboard/browser/templates/noticeboard.pt
+++ b/ftw/noticeboard/browser/templates/noticeboard.pt
@@ -4,19 +4,59 @@
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       i18n:domain="ftw.noticeboard">
 
+
+    <head>
+        <div metal:fill-slot="javascript_head_slot" tal:omit-tag="">
+            <script type="text/javascript">
+                (function($){
+                    function open(head, content) {
+                        head.addClass('open').attr('aria-expanded', true).attr('aria-disabled', false);
+                        content.removeAttr('hidden');
+                    }
+
+                    function close(head, content) {
+                        head.removeClass('open').attr('aria-expanded', false).attr('aria-disabled', true);
+                        content.attr('hidden', 'hidden');
+                    }
+
+                    $(document).on('click', '.collapsible-head', function(){
+                        const head = $(this);
+                        const content = $(this).next();
+                        if (content.is(':visible')) {
+                            close(head, content);
+                        } else {
+                            open(head, content);
+                        }
+                    });
+                }(jQuery));
+            </script>
+        </div>
+    </head>
+
+
     <div metal:fill-slot="content-core">
-        <tal:categories repeat="category view/get_categories_and_notices">
-            <div class="collapsible-head">
-                <h2 tal:content="category/title" />
-            </div>
-            <div class="collabsible-content">
-                <tal:notices repeat="notice category/notices">
-                    <div class="notice-wrapper">
-                        <span class="expiration-date" tal:content="notice/expires"/>
-                        <h3><a tal:attributes="href notice/url" tal:content="notice/title"/></h3>
-                    </div>
-                </tal:notices>
-            </div>
-        </tal:categories>
+        <ul tal:repeat="category view/get_categories_and_notices">
+            <li>
+                <div class="collapsible-head"
+                     aria-expanded="false"
+                     aria-disabled="true"
+                     tal:attributes="id category/id;
+                                     aria-controls string:content-${category/id}">
+                    <h2 tal:content="category/title" />
+                    <span class="icon" />
+                </div>
+                <div class="collabsible-content"
+                     tal:attributes="aria-labelledby category/id;
+                                    id string:content-{category/id}"
+                     role="region" hidden>
+                    <tal:notices repeat="notice category/notices">
+                        <div class="notice-wrapper">
+                            <span class="expiration-date" tal:content="notice/expires"/>
+                            <h3><a tal:attributes="href notice/url" tal:content="notice/title"/></h3>
+                        </div>
+                    </tal:notices>
+                </div>
+            </li>
+        </ul>
     </div>
 </html>


### PR DESCRIPTION
Accessibility -> Implemented according to https://www.w3.org/TR/wai-aria-practices/examples/accordion/accordion.html

I also wrapped everything in a list, since regarding the semantics it's a list.

I does not behave like an accordion, but as a toggle. The customer left it open, which implementation we chose. This one was just simpler.

<img width="896" alt="Screen Shot 2020-05-15 at 16 58 02" src="https://user-images.githubusercontent.com/437933/82064782-83af7e80-96cd-11ea-9eaf-9cdcece6352c.png">
<img width="898" alt="Screen Shot 2020-05-15 at 16 57 54" src="https://user-images.githubusercontent.com/437933/82064785-85794200-96cd-11ea-9966-bbbc6d8ea98a.png">
