### PR TITLE
Implement NoticeBoard default workflow

### DIFF
--- a/ftw/noticeboard/configure.zcml
+++ b/ftw/noticeboard/configure.zcml
@@ -10,6 +10,7 @@
     <include package=".browser" />
     <include package=".content" />
     <include file="resources.zcml" />
+    <include file="lawgiver.zcml" />
 
     <genericsetup:registerProfile
         name="default"

--- a/ftw/noticeboard/content/image.py
+++ b/ftw/noticeboard/content/image.py
@@ -1,0 +1,29 @@
+from ftw.noticeboard import _
+from plone.autoform.interfaces import IFormFieldProvider
+from plone.dexterity.content import Item
+from plone.supermodel import model
+from plone.supermodel.directives import primary
+from zope.interface import alsoProvides
+from zope.interface import implements
+from zope.interface import Interface
+from plone.namedfile.field import NamedBlobImage
+
+
+class INoticeImage(Interface):
+    """Marker interface for the NoticeImage"""
+
+
+class INoticeImageSchema(model.Schema):
+
+    primary('image')
+    image = NamedBlobImage(
+        title=_(u'label_image', default=u'Image'),
+        required=True
+    )
+
+
+class NoticeImage(Item):
+    implements(INoticeImage)
+
+
+alsoProvides(INoticeImageSchema, IFormFieldProvider)

--- a/ftw/noticeboard/lawgiver.zcml
+++ b/ftw/noticeboard/lawgiver.zcml
@@ -11,6 +11,11 @@
         />
 
     <lawgiver:map_permissions
+        action_group="add notice images"
+        permissions="ftw.noticeboard: Add NoticeImage"
+        />
+
+    <lawgiver:map_permissions
         action_group="manage noticeboards"
         permissions="ftw.noticeboard: Add NoticeCategory,
                      ftw.noticeboard: Add NoticeBoard"

--- a/ftw/noticeboard/lawgiver.zcml
+++ b/ftw/noticeboard/lawgiver.zcml
@@ -1,0 +1,19 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:lawgiver="http://namespaces.zope.org/lawgiver"
+    i18n_domain="ftw.noticeboard">
+
+    <include package="ftw.lawgiver" file="meta.zcml" />
+
+    <lawgiver:map_permissions
+        action_group="add notices"
+        permissions="ftw.noticeboard: Add Notice"
+        />
+
+    <lawgiver:map_permissions
+        action_group="manage noticeboards"
+        permissions="ftw.noticeboard: Add NoticeCategory,
+                     ftw.noticeboard: Add NoticeBoard"
+        />
+
+</configure>

--- a/ftw/noticeboard/permissions.zcml
+++ b/ftw/noticeboard/permissions.zcml
@@ -17,4 +17,9 @@
         id="ftw.noticeboard.AddNoticeBoard"
         title="ftw.noticeboard: Add NoticeBoard"
         />
+
+    <permission
+        id="ftw.noticeboard.AddNoticeImage"
+        title="ftw.noticeboard: Add NoticeImage"
+        />
 </configure>

--- a/ftw/noticeboard/profiles/default/metadata.xml
+++ b/ftw/noticeboard/profiles/default/metadata.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <metadata>
     <dependencies>
+        <dependency>profile-ftw.lawgiver:default</dependency>
         <dependency>profile-ftw.datepicker:default</dependency>
         <dependency>profile-collective.quickupload:default</dependency>
         <dependency>profile-ftw.upgrade:default</dependency>

--- a/ftw/noticeboard/profiles/default/portlets.xml
+++ b/ftw/noticeboard/profiles/default/portlets.xml
@@ -6,7 +6,7 @@
                 type="collective.quickupload.QuickUploadPortlet"
                 name="quickupload">
         <property name="header">Upload</property>
-        <property name="upload_portal_type">Image</property>
+        <property name="upload_portal_type">ftw.noticeboard.NoticeImage</property>
     </assignment>
  -->
 

--- a/ftw/noticeboard/profiles/default/types.xml
+++ b/ftw/noticeboard/profiles/default/types.xml
@@ -3,4 +3,5 @@
   <object name="ftw.noticeboard.Notice" meta_type="Dexterity FTI" />
   <object name="ftw.noticeboard.NoticeCategory" meta_type="Dexterity FTI" />
   <object name="ftw.noticeboard.NoticeBoard" meta_type="Dexterity FTI" />
+  <object name="ftw.noticeboard.NoticeImage" meta_type="Dexterity FTI" />
 </object>

--- a/ftw/noticeboard/profiles/default/types/ftw.noticeboard.NoticeImage.xml
+++ b/ftw/noticeboard/profiles/default/types/ftw.noticeboard.NoticeImage.xml
@@ -5,34 +5,32 @@
         i18n:domain="ftw.noticeboard">
 
     <!-- Basic metadata -->
-    <property name="title" i18n:translate="">Notice</property>
+    <property name="title" i18n:translate="">NoticeImage</property>
     <property name="description"></property>
     <property name="icon_expr"></property>
     <property name="allow_discussion">False</property>
     <property name="global_allow">False</property>
     <property name="filter_content_types">True</property>
     <property name="allowed_content_types">
-        <element value="ftw.noticeboard.NoticeImage" />
     </property>
 
     <!-- schema interface -->
-    <property name="schema">ftw.noticeboard.content.notice.INoticeSchema</property>
+    <property name="schema">ftw.noticeboard.content.image.INoticeImageSchema</property>
 
     <!-- class used for content items -->
-    <property name="klass">ftw.noticeboard.content.notice.Notice</property>
+    <property name="klass">ftw.noticeboard.content.image.NoticeImage</property>
 
     <!-- add permission -->
-    <property name="add_permission">ftw.noticeboard.AddNotice</property>
+    <property name="add_permission">ftw.noticeboard.AddNoticeImage</property>
 
     <!-- enabled behaviors -->
     <property name="behaviors">
         <element value="plone.app.content.interfaces.INameFromTitle" />
         <element value="plone.app.dexterity.behaviors.metadata.IBasic" />
-        <element value="ftw.noticeboard.content.behaviors.INoticePublication" />
     </property>
 
     <!-- View information -->
-    <property name="default_view">@@notice_view</property>
+    <property name="default_view">@@view</property>
     <property name="default_view_fallback">False</property>
     <property name="view_methods">
     </property>

--- a/ftw/noticeboard/profiles/default/workflows.xml
+++ b/ftw/noticeboard/profiles/default/workflows.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<object name="portal_workflow" meta_type="Plone Workflow Tool">
+  <object name="noticeboard_workflow" meta_type="Workflow"/>
+  <bindings>
+     <type type_id="ftw.noticeboard.NoticeBoard">
+      <bound-workflow workflow_id="noticeboard_workflow"/>
+     </type>
+     <type type_id="ftw.noticeboard.NoticeCategory">
+      <bound-workflow workflow_id="noticeboard_workflow"/>
+     </type>
+     <type type_id="ftw.noticeboard.Notice">
+      <bound-workflow workflow_id="noticeboard_workflow"/>
+     </type>
+  </bindings>
+</object>

--- a/ftw/noticeboard/profiles/default/workflows.xml
+++ b/ftw/noticeboard/profiles/default/workflows.xml
@@ -11,5 +11,8 @@
      <type type_id="ftw.noticeboard.Notice">
       <bound-workflow workflow_id="noticeboard_workflow"/>
      </type>
+     <type type_id="ftw.noticeboard.NoticeImage">
+      <bound-workflow workflow_id="noticeboard_workflow"/>
+     </type>
   </bindings>
 </object>

--- a/ftw/noticeboard/profiles/default/workflows/noticeboard_workflow/.gitignore
+++ b/ftw/noticeboard/profiles/default/workflows/noticeboard_workflow/.gitignore
@@ -1,0 +1,1 @@
+result.xml

--- a/ftw/noticeboard/profiles/default/workflows/noticeboard_workflow/definition.xml
+++ b/ftw/noticeboard/profiles/default/workflows/noticeboard_workflow/definition.xml
@@ -195,7 +195,11 @@
       <permission-role>Manager</permission-role>
       <permission-role>Site Administrator</permission-role>
     </permission-map>
-    <permission-map name="ftw.noticeboard: Add NoticeImage" acquired="False"/>
+    <permission-map name="ftw.noticeboard: Add NoticeImage" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
     <permission-map name="ftw.slider: Add Container" acquired="False">
       <permission-role>Authenticated</permission-role>
       <permission-role>Manager</permission-role>

--- a/ftw/noticeboard/profiles/default/workflows/noticeboard_workflow/definition.xml
+++ b/ftw/noticeboard/profiles/default/workflows/noticeboard_workflow/definition.xml
@@ -1,0 +1,265 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dc-workflow workflow_id="noticeboard_workflow" title="Noticeboard Workflow" description="Default and example workflow for the Noticeboard" initial_state="noticeboard_workflow--STATUS--visible" state_variable="review_state" manager_bypass="True">
+  <permission>ATContentTypes: Add Document</permission>
+  <permission>ATContentTypes: Add Event</permission>
+  <permission>ATContentTypes: Add File</permission>
+  <permission>ATContentTypes: Add Folder</permission>
+  <permission>ATContentTypes: Add Image</permission>
+  <permission>ATContentTypes: Add Large Plone Folder</permission>
+  <permission>ATContentTypes: Add Link</permission>
+  <permission>ATContentTypes: Add News Item</permission>
+  <permission>Access contents information</permission>
+  <permission>Add Folders</permission>
+  <permission>Add portal content</permission>
+  <permission>Add portal events</permission>
+  <permission>Add portal folders</permission>
+  <permission>Add portal topics</permission>
+  <permission>CMFEditions: Access previous versions</permission>
+  <permission>CMFEditions: Apply version control</permission>
+  <permission>CMFEditions: Checkout to location</permission>
+  <permission>CMFEditions: Revert to previous versions</permission>
+  <permission>CMFEditions: Save new version</permission>
+  <permission>Change local roles</permission>
+  <permission>Delete objects</permission>
+  <permission>Edit comments</permission>
+  <permission>List folder contents</permission>
+  <permission>Manage properties</permission>
+  <permission>Modify constrain types</permission>
+  <permission>Modify portal content</permission>
+  <permission>Modify view template</permission>
+  <permission>Portlets: Manage portlets</permission>
+  <permission>Sharing page: Delegate Contributor role</permission>
+  <permission>Sharing page: Delegate Editor role</permission>
+  <permission>Sharing page: Delegate Reader role</permission>
+  <permission>Sharing page: Delegate Reviewer role</permission>
+  <permission>Sharing page: Delegate roles</permission>
+  <permission>Take ownership</permission>
+  <permission>View</permission>
+  <permission>ftw.noticeboard: Add Notice</permission>
+  <permission>ftw.noticeboard: Add NoticeBoard</permission>
+  <permission>ftw.noticeboard: Add NoticeCategory</permission>
+  <permission>ftw.noticeboard: Add NoticeImage</permission>
+  <permission>ftw.slider: Add Container</permission>
+  <permission>ftw.slider: Add Pane</permission>
+  <permission>iterate : Check in content</permission>
+  <permission>iterate : Check out content</permission>
+  <permission>plone.app.collection: Add Collection</permission>
+  <permission>plone.portlet.collection: Add collection portlet</permission>
+  <permission>plone.portlet.static: Add static portlet</permission>
+  <state state_id="noticeboard_workflow--STATUS--visible" title="Visible">
+    <permission-map name="ATContentTypes: Add Document" acquired="False">
+      <permission-role>Authenticated</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map name="ATContentTypes: Add Event" acquired="False">
+      <permission-role>Authenticated</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map name="ATContentTypes: Add File" acquired="False">
+      <permission-role>Authenticated</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map name="ATContentTypes: Add Folder" acquired="False">
+      <permission-role>Authenticated</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map name="ATContentTypes: Add Image" acquired="False">
+      <permission-role>Authenticated</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map name="ATContentTypes: Add Large Plone Folder" acquired="False">
+      <permission-role>Authenticated</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map name="ATContentTypes: Add Link" acquired="False">
+      <permission-role>Authenticated</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map name="ATContentTypes: Add News Item" acquired="False">
+      <permission-role>Authenticated</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map name="Access contents information" acquired="False">
+      <permission-role>Authenticated</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map name="Add Folders" acquired="False">
+      <permission-role>Authenticated</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map name="Add portal content" acquired="False">
+      <permission-role>Authenticated</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map name="Add portal events" acquired="False">
+      <permission-role>Authenticated</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map name="Add portal folders" acquired="False">
+      <permission-role>Authenticated</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map name="Add portal topics" acquired="False">
+      <permission-role>Authenticated</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Access previous versions" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Apply version control" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Checkout to location" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Revert to previous versions" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Save new version" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map name="Change local roles" acquired="False"/>
+    <permission-map name="Delete objects" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map name="Edit comments" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map name="List folder contents" acquired="False">
+      <permission-role>Authenticated</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map name="Manage properties" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map name="Modify constrain types" acquired="False"/>
+    <permission-map name="Modify portal content" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map name="Modify view template" acquired="False"/>
+    <permission-map name="Portlets: Manage portlets" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Contributor role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Editor role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Reader role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Reviewer role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate roles" acquired="False"/>
+    <permission-map name="Take ownership" acquired="False"/>
+    <permission-map name="View" acquired="False">
+      <permission-role>Authenticated</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map name="ftw.noticeboard: Add Notice" acquired="False">
+      <permission-role>Authenticated</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map name="ftw.noticeboard: Add NoticeBoard" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map name="ftw.noticeboard: Add NoticeCategory" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map name="ftw.noticeboard: Add NoticeImage" acquired="False"/>
+    <permission-map name="ftw.slider: Add Container" acquired="False">
+      <permission-role>Authenticated</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map name="ftw.slider: Add Pane" acquired="False">
+      <permission-role>Authenticated</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map name="iterate : Check in content" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map name="iterate : Check out content" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map name="plone.app.collection: Add Collection" acquired="False">
+      <permission-role>Authenticated</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False"/>
+    <permission-map name="plone.portlet.static: Add static portlet" acquired="False"/>
+  </state>
+  <variable variable_id="action" for_catalog="False" for_status="True" update_always="True">
+    <description>Previous transition</description>
+    <default>
+        <expression>transition/getId|nothing</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="actor" for_catalog="False" for_status="True" update_always="True">
+<description>The ID of the user who performed the previous transition</description>
+    <default>
+        <expression>user/getId</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="comments" for_catalog="False" for_status="True" update_always="True">
+    <description>Comment about the last transition</description>
+    <default>
+        <expression>python:state_change.kwargs.get('comment', '')</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="review_history" for_catalog="False" for_status="False" update_always="False">
+    <description>Provides access to workflow history</description>
+    <default>
+        <expression>state_change/getHistory</expression>
+    </default>
+    <guard>
+        <guard-permission>Request review</guard-permission>
+        <guard-permission>Review portal content</guard-permission>
+    </guard>
+</variable>
+  <variable variable_id="time" for_catalog="False" for_status="True" update_always="True">
+    <description>When the previous transition was performed</description>
+    <default>
+        <expression>state_change/getDateTime</expression>
+    </default>
+    <guard/>
+</variable>
+</dc-workflow>

--- a/ftw/noticeboard/profiles/default/workflows/noticeboard_workflow/specification.txt
+++ b/ftw/noticeboard/profiles/default/workflows/noticeboard_workflow/specification.txt
@@ -1,0 +1,25 @@
+[Noticeboard Workflow]
+Description: Default and example workflow for the Noticeboard
+Initial Status: Visible
+
+Role mapping:
+  Owner => Owner
+  User => Authenticated
+  Site Administrator => Site Administrator
+  Manager => Manager
+
+
+Status Visible:
+  An Owner can always edit content.
+  An Owner can always delete content.
+
+  A User can add notices.
+  A User can add content.
+  A User can always view content.
+
+  A Site Administrator can manage noticeboards
+  An Site Administrator can always edit any content.
+  An Site Administrator can always delete any content.
+  A Site Administrator can always perform the same actions as a Owner.
+  A Site Administrator can always perform the same actions as a User.
+  A Manager can always perform the same actions as a Site Administrator.

--- a/ftw/noticeboard/profiles/default/workflows/noticeboard_workflow/specification.txt
+++ b/ftw/noticeboard/profiles/default/workflows/noticeboard_workflow/specification.txt
@@ -12,6 +12,7 @@ Role mapping:
 Status Visible:
   An Owner can always edit content.
   An Owner can always delete content.
+  An Owner can always add notice images.
 
   A User can add notices.
   A User can add content.

--- a/ftw/noticeboard/profiles/uninstall/types.xml
+++ b/ftw/noticeboard/profiles/uninstall/types.xml
@@ -3,4 +3,5 @@
   <object name="ftw.noticeboard.Notice" meta_type="Dexterity FTI" remove="True" />
   <object name="ftw.noticeboard.NoticeCategory" meta_type="Dexterity FTI" remove="True" />
   <object name="ftw.noticeboard.NoticeBoard" meta_type="Dexterity FTI" remove="True" />
+  <object name="ftw.noticeboard.NoticeImage" meta_type="Dexterity FTI" remove="True" />
 </object>

--- a/ftw/noticeboard/profiles/uninstall/workflows.xml
+++ b/ftw/noticeboard/profiles/uninstall/workflows.xml
@@ -6,5 +6,6 @@
     <type type_id="ftw.noticeboard.Notice" remove="True"/>
     <type type_id="ftw.noticeboard.NoticeBoard" remove="True"/>
     <type type_id="ftw.noticeboard.NoticeCategory" remove="True"/>
+    <type type_id="ftw.noticeboard.NoticeImage" remove="True"/>
   </bindings>
 </object>

--- a/ftw/noticeboard/profiles/uninstall/workflows.xml
+++ b/ftw/noticeboard/profiles/uninstall/workflows.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<object name="portal_workflow" meta_type="Plone Workflow Tool">
+  <object name="noticeboard_workflow" meta_type="Workflow" remove="True"/>
+
+  <bindings>
+    <type type_id="ftw.noticeboard.Notice" remove="True"/>
+    <type type_id="ftw.noticeboard.NoticeBoard" remove="True"/>
+    <type type_id="ftw.noticeboard.NoticeCategory" remove="True"/>
+  </bindings>
+</object>

--- a/ftw/noticeboard/tests/builders.py
+++ b/ftw/noticeboard/tests/builders.py
@@ -1,4 +1,5 @@
 from ftw.builder import builder_registry
+from ftw.builder.content import ImageBuilderMixin
 from ftw.builder.dexterity import DexterityBuilder
 
 
@@ -21,3 +22,10 @@ class NoticeBuilder(DexterityBuilder):
 
 
 builder_registry.register('notice', NoticeBuilder)
+
+
+class NoticeImageBuilder(ImageBuilderMixin, DexterityBuilder):
+    portal_type = 'ftw.noticeboard.NoticeImage'
+
+
+builder_registry.register('noticeimage', NoticeImageBuilder)

--- a/ftw/noticeboard/tests/test_notice_view.py
+++ b/ftw/noticeboard/tests/test_notice_view.py
@@ -31,7 +31,7 @@ class TestNoticeView(FunctionalTestCase):
         notice = self._create_content()
 
         for number in range(4):
-            create(Builder('image').within(notice).with_dummy_content())
+            create(Builder('noticeimage').within(notice).with_dummy_content())
 
         browser.login().visit(notice)
         self.assertEqual(

--- a/ftw/noticeboard/tests/test_noticeboard_workflow.py
+++ b/ftw/noticeboard/tests/test_noticeboard_workflow.py
@@ -1,0 +1,87 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.noticeboard.tests import FunctionalTestCase
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import factoriesmenu
+from ftw.testbrowser.pages import plone
+from plone.app.textfield.value import RichTextValue
+
+
+class TestNoticeBoardWorkflow(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestNoticeBoardWorkflow, self).setUp()
+        self.grant('Manager')
+
+    @browsing
+    def test_user_can_only_add_and_edit_notices(self, browser):
+        user = create(Builder('user'))
+        browser.login(user).visit()
+        with self.assertRaises(ValueError):
+            # ValueError: Cannot add "NoticeBoard": no factories menu visible
+            factoriesmenu.add('NoticeBoard')
+
+        noticeboard = create(Builder('noticeboard'))
+        browser.visit(noticeboard)
+
+        with self.assertRaises(ValueError):
+            # ValueError: Cannot add "NoticeBoard": no factories menu visible
+            factoriesmenu.add('NoticeCategory')
+
+        category = create(Builder('noticecategory').within(noticeboard))
+        browser.visit(category)
+        factoriesmenu.add('Notice')
+
+        browser.fill(
+            {
+                'Title': u'This is a Notice',
+                'Price': '100',
+                'Terms and Conditions': True,
+                'E-Mail': u'hans@peter.example',
+                'Text': u'Anything',
+            }
+        )
+        browser.find_button_by_label('Save').click()
+        self.assertEquals(u'This is a Notice', plone.first_heading())
+
+        browser.visit('@@edit')
+        browser.fill(
+            {
+                'Title': u'Changed',
+            }
+        )
+        browser.find_button_by_label('Save').click()
+        self.assertEquals(u'Changed', plone.first_heading())
+
+    @browsing
+    def test_user_can_only_add_images_on_notices_he_created(self, browser):
+        user = create(Builder('user'))
+
+        noticeboard = create(Builder('noticeboard'))
+        category = create(Builder('noticecategory').within(noticeboard))
+        othernotice = create(Builder('notice')
+                             .titled(u'This is a Notice')
+                             .having(accept_conditions=True,
+                                     text=RichTextValue('Something'),
+                                     price='100')
+                             .within(category))
+
+        browser.login(user).visit(othernotice)
+        self.assertFalse(factoriesmenu.visible())
+
+        browser.visit(category)
+        factoriesmenu.add('Notice')
+
+        browser.fill(
+            {
+                'Title': u'This is a Notice',
+                'Price': '100',
+                'Terms and Conditions': True,
+                'E-Mail': u'hans@peter.example',
+                'Text': u'Anything',
+            }
+        )
+        browser.find_button_by_label('Save').click()
+        self.assertEqual(
+            ['NoticeImage', ],
+            factoriesmenu.addable_types())

--- a/ftw/noticeboard/tests/test_workflow_specification.py
+++ b/ftw/noticeboard/tests/test_workflow_specification.py
@@ -1,0 +1,7 @@
+from ftw.lawgiver.tests.base import WorkflowTest
+from ftw.noticeboard.testing import NOTICEBOARD_FUNCTIONAL
+
+
+class TestBernWorkflowSpecification(WorkflowTest):
+    layer = NOTICEBOARD_FUNCTIONAL
+    workflow_path = '../profiles/default/workflows/noticeboard_workflow'

--- a/setup.py
+++ b/setup.py
@@ -47,13 +47,14 @@ setup(
 
     install_requires=[
         'Plone',
-        'setuptools',
-        'ftw.upgrade',
         'collective.quickupload',
         'ftw.datepicker',
+        'ftw.lawgiver',
         'ftw.slider',
         'ftw.theming',
+        'ftw.upgrade',
         'plone.api',
+        'setuptools',
     ],
 
     tests_require=tests_require,


### PR DESCRIPTION
- Add lawgiver based default workflow
- Add some basic tests for the workflow, even though this is basically testing lawgiver, but it helps to understand how the modul is supposed tow work.
- Add a separate image type, in order to control the add image permission. Otherwise a User would be able to add images in all Notices (Plone default add image permission is combined in "Add portal content"