### PR TITLE
Add my notices view, which shows all my notices even if they are inactive.

### DIFF
--- a/ftw/noticeboard/browser/configure.zcml
+++ b/ftw/noticeboard/browser/configure.zcml
@@ -29,6 +29,14 @@
         />
 
     <browser:page
+        for="ftw.noticeboard.content.noticeboard.INoticeBoard"
+        name="my-notices"
+        permission="zope2.View"
+        class=".noticeboard.MyNoticesView"
+        template="templates/noticeboard.pt"
+        />
+
+    <browser:page
         for="ftw.noticeboard.content.category.INoticeCategory"
         name="category_view"
         permission="zope2.View"

--- a/ftw/noticeboard/browser/noticeboard.py
+++ b/ftw/noticeboard/browser/noticeboard.py
@@ -1,8 +1,13 @@
+from ftw.noticeboard import _
 from plone import api
+from zope.i18n import translate
 from zope.publisher.browser import BrowserView
 
 
 class NoticeBoardView(BrowserView):
+
+    def get_title(self):
+        return self.context.Title()
 
     def _get_base_query(self):
         return {'portal_type': 'ftw.noticeboard.Notice'}
@@ -43,6 +48,9 @@ class NoticeBoardView(BrowserView):
 
 
 class MyNoticesView(NoticeBoardView):
+
+    def get_title(self):
+        return translate(_(u'label_my_notices', default=u'My Notices'), context=self.request)
 
     def _get_base_query(self):
         query = super(MyNoticesView, self)._get_base_query()

--- a/ftw/noticeboard/browser/noticeboard.py
+++ b/ftw/noticeboard/browser/noticeboard.py
@@ -4,6 +4,9 @@ from zope.publisher.browser import BrowserView
 
 class NoticeBoardView(BrowserView):
 
+    def _get_base_query(self):
+        return {'portal_type': 'ftw.noticeboard.Notice'}
+
     def get_categories(self):
         return self.context.listFolderContents()  # not a catalog query
 
@@ -18,8 +21,9 @@ class NoticeBoardView(BrowserView):
         results = []
 
         for category in self.get_categories():
-            notices = catalog(path='/'.join(category.getPhysicalPath()),
-                              portal_type='ftw.noticeboard.Notice')
+            query = self._get_base_query()
+            query['path'] = '/'.join(category.getPhysicalPath())
+            notices = catalog(**query)
             results.append(
                 {
                     'title': category.Title,
@@ -35,3 +39,16 @@ class NoticeBoardView(BrowserView):
                 }
             )
         return results
+
+
+class MyNoticesView(NoticeBoardView):
+
+    def _get_base_query(self):
+        query = super(MyNoticesView, self)._get_base_query()
+        query.update(
+            {
+                'show_inactive': True,
+                'Creator': api.user.get_current().getId()
+            }
+        )
+        return query

--- a/ftw/noticeboard/browser/noticeboard.py
+++ b/ftw/noticeboard/browser/noticeboard.py
@@ -29,6 +29,7 @@ class NoticeBoardView(BrowserView):
                     'title': category.Title,
                     'id': category.id,
                     'url': category.absolute_url(),
+                    'amount': len(notices),
                     'notices': [
                         {
                             'title': notice.Title,

--- a/ftw/noticeboard/browser/templates/noticeboard.pt
+++ b/ftw/noticeboard/browser/templates/noticeboard.pt
@@ -34,6 +34,11 @@
     </head>
 
 
+    <metal:content-title fill-slot="content-title">
+        <h1 class="documentFirstHeading" tal:content="view/get_title" />
+    </metal:content-title>
+
+
     <div metal:fill-slot="content-core">
         <ul tal:repeat="category view/get_categories_and_notices">
             <li>

--- a/ftw/noticeboard/browser/templates/noticeboard.pt
+++ b/ftw/noticeboard/browser/templates/noticeboard.pt
@@ -42,7 +42,7 @@
                      aria-disabled="true"
                      tal:attributes="id category/id;
                                      aria-controls string:content-${category/id}">
-                    <h2 tal:content="category/title" />
+                    <h2 tal:content="string:${category/title} (${category/amount})" />
                     <span class="icon" />
                 </div>
                 <div class="collabsible-content"

--- a/ftw/noticeboard/tests/test_my_notices_view.py
+++ b/ftw/noticeboard/tests/test_my_notices_view.py
@@ -1,0 +1,67 @@
+from datetime import datetime
+from datetime import timedelta
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.noticeboard.tests import FunctionalTestCase
+from ftw.testbrowser import browsing
+from plone.app.testing import login
+from plone.app.testing import logout
+from plone.app.textfield.value import RichTextValue
+
+
+class TestMyNoticeBoardView(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestMyNoticeBoardView, self).setUp()
+        self.grant('Manager')
+
+    def _create_content(self):
+        user = create(Builder('user'))
+        noticeboard = create(Builder('noticeboard').titled(u'Noticeboard'))
+        category1 = create(Builder('noticecategory')
+                           .having(conditions=RichTextValue('Something'))
+                           .titled(u'Category 1')
+                           .within(noticeboard))
+        category2 = create(Builder('noticecategory')
+                           .having(conditions=RichTextValue('Something'))
+                           .titled(u'Category 2')
+                           .within(noticeboard))
+
+        for number in range(1, 4):
+            create(Builder('notice')
+                   .titled(u'Notice {0}'.format(str(number)))
+                   .having(accept_conditions=True,
+                           text=RichTextValue('Something'),
+                           price='100',
+                           expires=datetime.now() - timedelta(days=10))
+                   .within(category1))
+
+        login(self.portal, user.getId())
+        for number in range(1, 2):
+            create(Builder('notice')
+                   .titled(u'Notice {0}'.format(str(number)))
+                   .having(accept_conditions=True,
+                           text=RichTextValue('Something'),
+                           price='100',
+                           expires=datetime.now() - timedelta(days=10))
+                   .within(category2))
+        logout()
+
+        return noticeboard, user
+
+    @browsing
+    def test_show_only_my_notices_and_inactive_notices(self, browser):
+        board, user = self._create_content()
+
+        browser.login(user).visit(board)
+        self.assertFalse(
+            len(browser.css('.collabsible-content h3')),
+            'Expect no notices, since all of them are expired'
+        )
+
+        browser.login(user).visit(board, view='my-notices')
+        self.assertEqual(
+            1,
+            len(browser.css('.collabsible-content h3')),
+            'Expect one notices, since the logged in user is owner of 1 Notice'
+        )

--- a/ftw/noticeboard/tests/test_noticeboard_view.py
+++ b/ftw/noticeboard/tests/test_noticeboard_view.py
@@ -46,7 +46,7 @@ class TestNoticeBoardView(FunctionalTestCase):
         browser.login().visit(noticeboard)
 
         self.assertListEqual(
-            ['Category 1', 'Category 2'],
+            ['Category 1 (3)', 'Category 2 (1)'],
             browser.css('.template-noticeboard_view .collapsible-head').text,
             'Expected two categories'
         )


### PR DESCRIPTION
The view looks exactly the same as the normal notice board view, but shows all notices created by the user, even if they are inactive (expired)

Additional changes:
- Show amount of notices per category, so people do not click on the and see a empty result.
- Change title of "my notices"