### PR TITLE
Add some links and other helping mini changes. 

### DIFF
--- a/ftw/noticeboard/browser/noticeboard.py
+++ b/ftw/noticeboard/browser/noticeboard.py
@@ -6,6 +6,12 @@ from zope.publisher.browser import BrowserView
 
 class NoticeBoardView(BrowserView):
 
+    def __call__(self):
+        user_roles = api.user.get_roles(obj=self.context)
+        if not {'Manager', 'Site Administrator'} & set(user_roles):
+            self.request.set('disable_border', True)
+        return super(NoticeBoardView, self).__call__()
+
     def get_title(self):
         return self.context.Title()
 

--- a/ftw/noticeboard/browser/noticeboard.py
+++ b/ftw/noticeboard/browser/noticeboard.py
@@ -9,6 +9,10 @@ class NoticeBoardView(BrowserView):
     def get_title(self):
         return self.context.Title()
 
+    @property
+    def name(self):
+        return self.__name__
+
     def _get_base_query(self):
         return {'portal_type': 'ftw.noticeboard.Notice'}
 

--- a/ftw/noticeboard/browser/noticeboard.py
+++ b/ftw/noticeboard/browser/noticeboard.py
@@ -39,6 +39,8 @@ class NoticeBoardView(BrowserView):
                     'id': category.id,
                     'url': category.absolute_url(),
                     'amount': len(notices),
+                    'addview': '{0}/++add++ftw.noticeboard.Notice'.format(category.absolute_url()),
+                    'canadd': api.user.has_permission('ftw.noticeboard: Add Notice', obj=category),
                     'notices': [
                         {
                             'title': notice.Title,

--- a/ftw/noticeboard/browser/templates/notice.pt
+++ b/ftw/noticeboard/browser/templates/notice.pt
@@ -42,6 +42,6 @@
             </div>
         </div>
         <div class="notice-description" tal:condition="context/Description" tal:content="context/Description"/>
-        <div class="notice-text" tal:content="structure context/text/output"/>
+        <div class="notice-text" tal:content="structure context/text/output | nothing"/>
     </div>
 </html>

--- a/ftw/noticeboard/browser/templates/noticeboard.pt
+++ b/ftw/noticeboard/browser/templates/noticeboard.pt
@@ -40,6 +40,11 @@
 
 
     <div metal:fill-slot="content-core">
+
+        <div class="my-notices" tal:condition="python: view.name == 'noticeboard_view'">
+            <a href="./my-notices" i18n:translate="label_my_notices">My Notices</a>
+        </div>
+
         <ul tal:repeat="category view/get_categories_and_notices">
             <li>
                 <div class="collapsible-head"

--- a/ftw/noticeboard/browser/templates/noticeboard.pt
+++ b/ftw/noticeboard/browser/templates/noticeboard.pt
@@ -59,6 +59,11 @@
                      tal:attributes="aria-labelledby category/id;
                                     id string:content-{category/id}"
                      role="region" hidden>
+
+                     <tal:addlink condition="category/canadd">
+                        <a class="add-link" tal:attributes="href category/addview" i18n:translate="label_add_new_notice">Add new Notice to this categroy</a>
+                     </tal:addlink>
+
                     <tal:notices repeat="notice category/notices">
                         <div class="notice-wrapper">
                             <span class="expiration-date" tal:content="notice/expires"/>

--- a/ftw/noticeboard/tests/test_noticeboard_workflow.py
+++ b/ftw/noticeboard/tests/test_noticeboard_workflow.py
@@ -31,7 +31,7 @@ class TestNoticeBoardWorkflow(FunctionalTestCase):
 
         category = create(Builder('noticecategory').within(noticeboard))
         browser.visit(category)
-        factoriesmenu.add('Notice')
+        browser.css('a.add-link').first.click()  # factoriesmenu.add('Notice')
 
         browser.fill(
             {
@@ -71,7 +71,7 @@ class TestNoticeBoardWorkflow(FunctionalTestCase):
         self.assertFalse(factoriesmenu.visible())
 
         browser.visit(category)
-        factoriesmenu.add('Notice')
+        browser.css('a.add-link').first.click()  # factoriesmenu.add('Notice')
 
         browser.fill(
             {
@@ -105,7 +105,7 @@ class TestNoticeBoardWorkflow(FunctionalTestCase):
             browser.find_button_by_label('Delete').click()
 
         browser.visit(category)
-        factoriesmenu.add('Notice')
+        browser.css('a.add-link').first.click()  # factoriesmenu.add('Notice')
         browser.fill(
             {
                 'Title': u'This is a Notice',


### PR DESCRIPTION
- Show "my notices" on noticeboard --> Directly access all my notices.
- Add Notice link per category. --> Directly add Notices from NoticeBoard.
- Hide editable borders on Noticeboard and NoticeCategory for non admin users.