### PR TITLE
Various display optimisations. 

### DIFF
--- a/ftw/noticeboard/browser/resources/slider.scss
+++ b/ftw/noticeboard/browser/resources/slider.scss
@@ -1,0 +1,30 @@
+.notice-image-slider.slick-slider {
+  // Buttons next/prev
+  > button {
+    min-height: 2em;
+    min-width: 2em;
+    font-size: 0;
+    z-index: 1;
+
+    &:before {
+      font-size: 1rem;
+      line-height: 1.5rem;
+    }
+
+    &:hover {
+      background-color: #fff;
+    }
+
+    &.slick-next {
+      margin-top: -2em;
+      top: calc(50% - 1rem);
+      right: 0;
+    }
+
+    &.slick-prev {
+      left: 0;
+      top: calc(50% - 1rem);
+      margin-top: -2em;
+    }
+  }
+}

--- a/ftw/noticeboard/browser/resources/styles.scss
+++ b/ftw/noticeboard/browser/resources/styles.scss
@@ -1,11 +1,37 @@
+$noticebard-color-collapsible-head: $color-primary !default;
+$noticebard-bg-collapsible-head: #e6e6e6 !default;
+$noticebard-bg-collapsible-head-open: $color-primary !default;
+
+
+@include declare-variables(noticebard-color-collapsible-head,
+                           noticebard-bg-collapsible-head,
+                           noticebard-bg-collapsible-head-open);
+
+
 .template-noticeboard_view {
-  ul {
-    @include ul(plain);    
+
+  .my-notices {
+    margin: $margin-vertical 0;
+  }
+
+  #content-core ul {
+    @include ul(plain);
+
+    li {
+      margin: $margin-vertical / 2 0;
+    }
   }
 
   .collapsible-head {
     position: relative;
     cursor: pointer;
+    padding: $padding-vertical $padding-horizontal;
+    background-color: $noticebard-bg-collapsible-head;
+    color: $noticebard-color-collapsible-head;
+
+    h2 {
+        margin: 0;
+    }
 
     .icon {
       display: block;
@@ -16,8 +42,26 @@
       @extend .fa-icon;
       @extend .fa-plus-circle;
     }
-    &.open .icon {
-      @extend .fa-minus-circle; 
+    &.open {
+      background-color: $noticebard-bg-collapsible-head-open;
+      @include auto-text-color($noticebard-bg-collapsible-head-open);
+
+      .icon {
+        @extend .fa-minus-circle; 
+      }
+    }
+  }
+  .collapsible-content {
+    h3 {
+      margin: 0;
+    }
+    .notice-wrapper, .add-link {
+      display: block;
+      padding:$padding-vertical 0;
+      border-bottom: 1px solid $color-gray-dark;
+      &:last-child {
+        border-bottom: 0;
+      }
     }
   }
 }
@@ -52,6 +96,11 @@
     padding-left: $padding-horizontal;
   }
 
+  .notice-details.no-images {
+    width: 100%;
+    padding-left: 0;
+  }
+
   .label {
     font-weight: normal;
     display: block
@@ -62,7 +111,10 @@
   }
 }
 
-.notice-description {
+.notice-description, .notice-text {
   margin: $margin-vertical 0;
+}
+
+.notice-description {
   font-weight: bold;
 }

--- a/ftw/noticeboard/browser/templates/notice.pt
+++ b/ftw/noticeboard/browser/templates/notice.pt
@@ -20,15 +20,16 @@
     </head>
 
     <div metal:fill-slot="main">
-        <div class="notice-detail-wrapper">
-            <div class="notice-image-slider">
-                <tal:images repeat="image context/listFolderContents">
+        <div class="notice-detail-wrapper" tal:define="images context/listFolderContents">
+            <div class="notice-image-slider" tal:condition="images">
+                <tal:images repeat="image images">
                     <div>
-                        <img tal:replace="structure image/images/image/large" />
+                        <img tal:define="scales image/@@images"
+                             tal:replace="structure python:scales.scale('image', width=400, height=400, direction='down').tag()" />
                     </div>
                 </tal:images>
             </div>
-            <div class="notice-details">
+            <div class="notice-details" tal:attributes="class python:images and 'notice-details' or 'notice-details no-images'">
                 <span class="expiration-date" tal:content="view/get_localized_expiration_date"/>
                 <h1 class="documentFirstHeading" tal:content="context/title"/>
                 <div class="price">

--- a/ftw/noticeboard/browser/templates/noticeboard.pt
+++ b/ftw/noticeboard/browser/templates/noticeboard.pt
@@ -55,7 +55,7 @@
                     <h2 tal:content="string:${category/title} (${category/amount})" />
                     <span class="icon" />
                 </div>
-                <div class="collabsible-content"
+                <div class="collapsible-content"
                      tal:attributes="aria-labelledby category/id;
                                     id string:content-{category/id}"
                      role="region" hidden>

--- a/ftw/noticeboard/profiles/default/propertiestool.xml
+++ b/ftw/noticeboard/profiles/default/propertiestool.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="portal_properties" meta_type="Plone Properties Tool">
+    <object name="navtree_properties" meta_type="Plone Property Sheet">
+        <property name="metaTypesNotToList" type="lines" purge="False">
+            <element value="ftw.noticeboard.Notice" />
+        </property>
+    </object>
+</object>

--- a/ftw/noticeboard/profiles/default/types/ftw.noticeboard.NoticeBoard.xml
+++ b/ftw/noticeboard/profiles/default/types/ftw.noticeboard.NoticeBoard.xml
@@ -28,6 +28,7 @@
     <property name="behaviors">
         <element value="plone.app.content.interfaces.INameFromTitle" />
         <element value="plone.app.dexterity.behaviors.metadata.IBasic" />
+        <element value="plone.app.dexterity.behaviors.exclfromnav.IExcludeFromNavigation" />
     </property>
 
     <!-- View information -->

--- a/ftw/noticeboard/profiles/uninstall/propertiestool.xml
+++ b/ftw/noticeboard/profiles/uninstall/propertiestool.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="portal_properties" meta_type="Plone Properties Tool">
+    <object name="navtree_properties" meta_type="Plone Property Sheet">
+        <property name="metaTypesNotToList" type="lines" purge="False">
+            <element value="ftw.noticeboard.Notice" remove="True" />
+        </property>
+    </object>
+</object>

--- a/ftw/noticeboard/resources.zcml
+++ b/ftw/noticeboard/resources.zcml
@@ -7,6 +7,7 @@
 
     <theme:resources profile="ftw.noticeboard:default" slot="addon">
         <theme:scss file="browser/resources/styles.scss" />
+        <theme:scss file="browser/resources/slider.scss" />
     </theme:resources>
 
 </configure>

--- a/ftw/noticeboard/tests/test_add_content.py
+++ b/ftw/noticeboard/tests/test_add_content.py
@@ -89,3 +89,7 @@ class TestContentTypes(FunctionalTestCase):
         browser.find_button_by_label('Save').click()
         self.assertEquals(u'Add Notice', plone.first_heading())
         statusmessages.assert_message('There were some errors.')
+        self.assertEqual(
+            u'You need to accept the terms and conditions',
+            browser.css('.fieldErrorBox > .error').first.text
+        )

--- a/ftw/noticeboard/tests/test_my_notices_view.py
+++ b/ftw/noticeboard/tests/test_my_notices_view.py
@@ -55,13 +55,13 @@ class TestMyNoticeBoardView(FunctionalTestCase):
 
         browser.login(user).visit(board)
         self.assertFalse(
-            len(browser.css('.collabsible-content h3')),
+            len(browser.css('.collapsible-content h3')),
             'Expect no notices, since all of them are expired'
         )
 
         browser.login(user).visit(board, view='my-notices')
         self.assertEqual(
             1,
-            len(browser.css('.collabsible-content h3')),
+            len(browser.css('.collapsible-content h3')),
             'Expect one notices, since the logged in user is owner of 1 Notice'
         )

--- a/ftw/noticeboard/tests/test_noticeboard_view.py
+++ b/ftw/noticeboard/tests/test_noticeboard_view.py
@@ -53,13 +53,13 @@ class TestNoticeBoardView(FunctionalTestCase):
 
         self.assertEquals(
             3,
-            len(browser.css('.collabsible-content').first.css('h3')),
+            len(browser.css('.collapsible-content').first.css('h3')),
             'Expect 3 notices in first category'
         )
 
         self.assertEquals(
             1,
-            len(browser.css('.collabsible-content')[1].css('h3')),
+            len(browser.css('.collapsible-content')[1].css('h3')),
             'Expect 1 notice in second category'
         )
 
@@ -70,7 +70,7 @@ class TestNoticeBoardView(FunctionalTestCase):
 
         browser.login().visit(noticeboard)
         # Click on first link in first category
-        browser.css('.collabsible-content').first.css('h3 a').first.click()
+        browser.css('.collapsible-content').first.css('h3 a').first.click()
         self.assertEqual(notice.absolute_url(), browser.url)
 
     @browsing
@@ -80,12 +80,12 @@ class TestNoticeBoardView(FunctionalTestCase):
 
         self.assertEqual(
             1,
-            len(browser.css('.collabsible-content')),
+            len(browser.css('.collapsible-content')),
             'Expect 1 content area')
 
         self.assertEquals(
             3,
-            len(browser.css('.collabsible-content').css('h3')),
+            len(browser.css('.collapsible-content').css('h3')),
             'Expect 3 notices in first category'
         )
 
@@ -93,6 +93,6 @@ class TestNoticeBoardView(FunctionalTestCase):
 
         self.assertEquals(
             1,
-            len(browser.css('.collabsible-content').css('h3')),
+            len(browser.css('.collapsible-content').css('h3')),
             'Expect 1 notice in second category'
         )


### PR DESCRIPTION
- Add ftw.theming specific stlyes - so it looks much better with blueberry, or onegovbear theme. I only added default spacing and I'm using predefined colors from ftw.theming. This is how it looks in bern.web.
   <img width="904" alt="Screen Shot 2020-05-19 at 09 31 00" src="https://user-images.githubusercontent.com/437933/82297830-80f5a780-99b3-11ea-9df7-62f3045e7a18.png">

- Addes slider specific styles
  <img width="606" alt="Screen Shot 2020-05-19 at 09 28 43" src="https://user-images.githubusercontent.com/437933/82297930-a97da180-99b3-11ea-90ce-fbaa1dde8829.png">

- Show a cropped squared image
- Fix display issues if there is no image
- Add IExcludeFromNavigation behavior to NoticeBoard
- Don't show Notices in navigation. 

