### PR TITLE
Setup quickupload portlet using hook from ftw.profilehook.

### DIFF
--- a/ftw/noticeboard/configure.zcml
+++ b/ftw/noticeboard/configure.zcml
@@ -4,6 +4,7 @@
     xmlns:five="http://namespaces.zope.org/five"
     xmlns:upgrade-step="http://namespaces.zope.org/ftw.upgrade"
     xmlns:i18n="http://namespaces.zope.org/i18n"
+    xmlns:profilehook="http://namespaces.zope.org/profilehook"
     i18n_domain="ftw.noticeboard">
 
     <five:registerPackage package="." initialize=".initialize" />
@@ -20,6 +21,11 @@
         title="ftw.noticeboard default"
         directory="profiles/default"
         provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
+    <profilehook:hook
+        profile="ftw.noticeboard:default"
+        handler=".hooks.add_quickupload_portlet"
         />
 
     <genericsetup:registerProfile

--- a/ftw/noticeboard/hooks.py
+++ b/ftw/noticeboard/hooks.py
@@ -1,0 +1,33 @@
+from collective.quickupload.portlet.quickuploadportlet import Assignment
+from plone.app.portlets.storage import PortletAssignmentMapping
+from plone.portlets.constants import CONTENT_TYPE_CATEGORY
+from plone.portlets.interfaces import IPortletManager
+from zope.component import getUtility
+
+
+def add_quickupload_portlet(portal):
+    # Do not set up quickupload portlet in profile's portlet.xml.
+    # The Form provided there does not work without a actual request.
+    # Thus we avoid to setup the portlet in tests.
+    # Note to future me: If you ever wanna reliable produce a segmentation fault,
+    # just remove the condition :-D
+    if portal.REQUEST.URL not in ['http://foo', 'http://nohost']:
+        manager = getUtility(IPortletManager, name='plone.rightcolumn')
+        category = manager.get(CONTENT_TYPE_CATEGORY)
+        portal_type = 'ftw.noticeboard.Notice'
+
+        mapping = category.get(portal_type, None)
+
+        if mapping is None:
+            mapping = mapping[portal_type] = PortletAssignmentMapping(
+                manager=manager,
+                category=CONTENT_TYPE_CATEGORY,
+                name=portal_type)
+
+        if 'quickupload' not in mapping:
+            portlet = Assignment(
+                header='Upload',
+                upload_portal_type='ftw.noticeboard.NoticeImage',
+                upload_media_type='image'
+            )
+            mapping['quickupload'] = portlet

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         'collective.quickupload',
         'ftw.datepicker',
         'ftw.lawgiver [deletepermission]',
+        'ftw.profilehook',
         'ftw.slider',
         'ftw.theming',
         'ftw.upgrade',


### PR DESCRIPTION
There is no uninstall step for this change, since it's content and the Integrators are responsible for content, not the package directly.

Closes #14 